### PR TITLE
Fix typo on age_suitability.html

### DIFF
--- a/docs/text_cls/age_suitability.html
+++ b/docs/text_cls/age_suitability.html
@@ -229,7 +229,7 @@
 </tr>
 </thead>
 <tbody>
-<tr class="row-even"><td><p>Nudiy</p></td>
+<tr class="row-even"><td><p>Nudity</p></td>
 <td><p>0.41</p></td>
 <td><p>0.41</p></td>
 </tr>


### PR DESCRIPTION
fix typo from `nudiy` to `nudity`

## Title

- fix typo on `age_suitability.html`

## Description

- There is a typo on `age_suitability.html` page. I think the word `Nudiy` should be fixed into `Nudity`. I've edited the `html` file directly in this PR. If this isn't a proper way to edit a published web document, please cancel this PR. Thank you. 

## Linked Issues

- #39 