### PR TITLE
Fix typo on para_gen docstrings and html

### DIFF
--- a/docs/seq2seq/para_gen.html
+++ b/docs/seq2seq/para_gen.html
@@ -229,7 +229,7 @@
 <tr class="row-even"><td><p>Average</p></td>
 <td><p>33.00</p></td>
 </tr>
-<tr class="row-odd"><td><p>Englosh</p></td>
+<tr class="row-odd"><td><p>English</p></td>
 <td><p>54</p></td>
 </tr>
 <tr class="row-even"><td><p>Korean</p></td>
@@ -267,7 +267,7 @@
 <tr class="row-even"><td><p>Average</p></td>
 <td><p>33.50</p></td>
 </tr>
-<tr class="row-odd"><td><p>Englosh</p></td>
+<tr class="row-odd"><td><p>English</p></td>
 <td><p>56</p></td>
 </tr>
 <tr class="row-even"><td><p>Korean</p></td>

--- a/pororo/tasks/paraphrase_generation.py
+++ b/pororo/tasks/paraphrase_generation.py
@@ -20,7 +20,7 @@ class PororoParaphraseFactory(PororoFactoryBase):
             +==========+============+
             | Average  |   33.00    |
             +----------+------------+
-            | Englosh  |   54       |
+            | English  |   54       |
             +----------+------------+
             | Korean   |   50       |
             +----------+------------+
@@ -39,7 +39,7 @@ class PororoParaphraseFactory(PororoFactoryBase):
             +==========+============+
             | Average  |   33.50    |
             +----------+------------+
-            | Englosh  |   56       |
+            | English  |   56       |
             +----------+------------+
             | Korean   |   50       |
             +----------+------------+


### PR DESCRIPTION
## Title

- fix typo on para_gen docstrings and html

## Description

- `Englosh` to `English`

## Linked Issues

- resolved #43 

MRC랑 한번에 PR 했어야 했는데.. 여러모로 번거롭게 해드려서 죄송합니다...