### PR TITLE
Improve MRC inference and change output

### DIFF
--- a/pororo/models/brainbert/BrainRoBERTa.py
+++ b/pororo/models/brainbert/BrainRoBERTa.py
@@ -241,22 +241,26 @@ class BrainRobertaHubInterface(RobertaHubInterface):
                 tokens,
                 return_logits=True,
             ).squeeze()  # T x 2
-            # first predict start position,
-            # then predict end position among the remaining logits
-            start = logits[:, 0].argmax().item()
-            mask = (torch.arange(
-                logits.size(0), dtype=torch.long, device=self.device) >= start)
-            end = (mask * logits[:, 1]).argmax().item()
-            # end position is shifted during training, so we add 1 back
-            answer_tokens = tokens[start:end + 1]
+            # predict top 10 start positions
+            # then predict top 10 end position among the remaining logits
+            results = []
+            starts = logits[:, 0].argsort(descending=True).tolist()
+            for start in starts:
+                mask = (torch.arange(
+                    logits.size(0), dtype=torch.long, device=self.device) >= start)
+                ends = (mask * logits[:, 1]).argsort(descending=True).tolist()
+                # end position is shifted during training, so we add 1 back
+                for end in ends:
+                    answer_tokens = tokens[start:end + 1]
+                    answer = ""
+                    if len(answer_tokens) >= 1:
+                        decoded = self.decode(answer_tokens)
+                        if isinstance(decoded, str):
+                            answer = decoded
+                    score = (logits[:,0][start] + logits[:,1][end]).item()
+                    results.append((answer, (start, end + 1), score))
 
-            answer = ""
-            if len(answer_tokens) >= 1:
-                decoded = self.decode(answer_tokens)
-                if isinstance(decoded, str):
-                    answer = decoded
-
-        return (answer, (start, end + 1))
+        return sorted(results,key=lambda x:x[2],reverse=True)[0]
 
     @torch.no_grad()
     def predict_tags(

--- a/pororo/models/brainbert/BrainRoBERTa.py
+++ b/pororo/models/brainbert/BrainRoBERTa.py
@@ -258,9 +258,9 @@ class BrainRobertaHubInterface(RobertaHubInterface):
                         if isinstance(decoded, str):
                             answer = decoded
                     score = (logits[:,0][start] + logits[:,1][end]).item()
-                    results.append((answer, (start, end + 1), score))
+                    results.append((answer, (start, end + 1), (logits[:,0][start].item(),logits[:,1][end].item()), score))
 
-        return sorted(results,key=lambda x:x[2],reverse=True)[0]
+        return sorted(results,key=lambda x:x[3],reverse=True)[0]
 
     @torch.no_grad()
     def predict_tags(

--- a/pororo/tasks/machine_reading_comprehension.py
+++ b/pororo/tasks/machine_reading_comprehension.py
@@ -113,4 +113,5 @@ class PororoBertMrc(PororoBiencoderBase):
         return (
             span,
             pair_result[1],
+            pair_result[2],
         )

--- a/pororo/tasks/machine_reading_comprehension.py
+++ b/pororo/tasks/machine_reading_comprehension.py
@@ -114,4 +114,5 @@ class PororoBertMrc(PororoBiencoderBase):
             span,
             pair_result[1],
             pair_result[2],
+            pair_result[3],
         )


### PR DESCRIPTION
## Title

- Improve MRC inference and change output

## Summary
- Predict span using top10 start&end position
- Add score output
- Add logit output

## Description

In predicting span in the MRC, the existing code used only the maximum value of start position and end position. For a more accurate inference, the top 10 start positions and end positions were used to predict the highest score span. At this time, the score is defined as the sum of start logit and end logit.
Finally, I added logit and score to the output for user convenience.

## Examples
```
>>> mrc = Pororo(task="mrc", lang="ko")
>>> mrc(
>>>    "카카오브레인이 공개한 것은?",
>>>    "카카오 인공지능(AI) 연구개발 자회사 카카오브레인이 AI 솔루션을 첫 상품화했다. 카카오는 카카오브레인 '포즈(pose·자세분석) API'를 유료 공개한다고 24일 밝혔다. 카카오브레인이 AI 기술을 유료 API를 공개하는 것은 처음이다. 공개하자마자 외부 문의가 쇄도한다. 포즈는 AI 비전(VISION, 영상·화면분석) 분야 중 하나다. 카카오브레인 포즈 API는 이미지나 영상을 분석해 사람 자세를 추출하는 기능을 제공한다."
>>> )
('포즈(pose·자세분석) API',
 (33, 44),
 (5.7833147048950195, 4.649877548217773),
 10.433192253112793)
>>> # when mecab doesn't work well for postprocess, you can set `postprocess` option as `False`
>>> mrc("카카오브레인이 공개한 라이브러리 이름은?", "카카오브레인은 자연어 처리와 음성 관련 태스크를 쉽게 수행할 수 있도록 도와 주는 라이브러리 pororo를 공개하였습니다.", postprocess=False)
('pororo', (31, 35), (8.656489372253418, 8.14583683013916), 16.802326202392578)
```